### PR TITLE
fix(deploy): harden fly deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,36 @@ Run integration tests:
 pytest tests/unit/integration -v
 ```
 
+---
+
+# Fly.io Deployment
+
+The Fly.io configuration for this project lives inside the repository root of this app:
+
+```bash
+agentic-ai-mcp-platform/fly.toml
+```
+
+Run deployment commands from the `agentic-ai-mcp-platform/` directory:
+
+```bash
+cd agentic-ai-mcp-platform
+fly deploy
+```
+
+Or provide the config file explicitly if you are deploying from a parent workspace:
+
+```bash
+fly deploy -c /path/to/agentic-ai-mcp-platform/fly.toml
+```
+
+Production deployments should also provide environment variables for the backend, especially:
+
+```bash
+DATABASE_URL=<production database url>
+API_KEY=<production api key>
+```
+
 Example output:
 
 ```

--- a/app/api/dependencies/auth.py
+++ b/app/api/dependencies/auth.py
@@ -13,9 +13,11 @@ from typing import Optional
 
 from fastapi import Header, HTTPException, status
 
+from app.core.config import get_settings
 
-# Temporary development key.
-# In production this should come from environment variables.
+
+# Temporary development default.
+# Production should override this through environment variables.
 DEV_API_KEY = "dev-secret-key"
 
 
@@ -32,8 +34,10 @@ async def require_api_key(
     This keeps authentication logic outside business logic.
     """
 
+    configured_api_key = get_settings().api_key
+
     # Reject if header is missing or incorrect
-    if x_api_key != DEV_API_KEY:
+    if x_api_key != configured_api_key:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing API key",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     host: str = "127.0.0.1"
     port: int = 8000
 
+    # Infrastructure
+    database_url: str = "sqlite:///./app.db"
+    api_key: str = "dev-secret-key"
+
     # AWS / Bedrock (placeholders for later)
     aws_region: str | None = None
 

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -18,6 +18,7 @@ from app.core.config import get_settings
 # ============================================================
 _engine: Optional[Any] = None
 
+
 # ============================================================
 # Engine Factory
 # ============================================================
@@ -36,7 +37,7 @@ def get_engine(test_engine: Optional[Any] = None):
 
     if _engine is None:
         settings = get_settings()
-        database_url = settings.DATABASE_URL
+        database_url = settings.database_url
         _engine = create_engine(
             database_url,
             echo=True,

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.api.dependencies.auth import require_api_key, DEV_API_KEY
+from app.core.config import get_settings
 
 
 async def test_require_api_key_valid():
@@ -38,3 +39,15 @@ async def test_require_api_key_empty():
         await require_api_key(x_api_key="")
 
     assert exc_info.value.status_code == 401
+
+
+async def test_require_api_key_uses_env_override(monkeypatch):
+    """Configured API key should come from environment settings."""
+    monkeypatch.setenv("API_KEY", "prod-key")
+    get_settings.cache_clear()
+
+    try:
+        result = await require_api_key(x_api_key="prod-key")
+        assert result == "prod-key"
+    finally:
+        get_settings.cache_clear()

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,0 +1,33 @@
+"""
+Unit tests for application settings.
+"""
+
+from app.core.config import get_settings
+
+
+def test_settings_include_safe_defaults(monkeypatch):
+    """Settings should expose deploy-relevant defaults."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
+    get_settings.cache_clear()
+
+    try:
+        settings = get_settings()
+        assert settings.database_url == "sqlite:///./app.db"
+        assert settings.api_key == "dev-secret-key"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_settings_read_env_overrides(monkeypatch):
+    """Settings should load DATABASE_URL and API_KEY from env."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./override.db")
+    monkeypatch.setenv("API_KEY", "override-key")
+    get_settings.cache_clear()
+
+    try:
+        settings = get_settings()
+        assert settings.database_url == "sqlite:///./override.db"
+        assert settings.api_key == "override-key"
+    finally:
+        get_settings.cache_clear()

--- a/tests/unit/core/test_db.py
+++ b/tests/unit/core/test_db.py
@@ -7,6 +7,8 @@ Tests database engine and session management.
 import pytest
 from sqlmodel import create_engine, Session, SQLModel
 
+import app.core.db as db_module
+from app.core.config import get_settings
 from app.core.db import get_engine, get_session, init_db
 
 
@@ -42,3 +44,17 @@ def test_init_db_with_test_engine(test_engine):
     """init_db should initialize schema with test engine."""
     # Should not raise
     init_db(test_engine)
+
+
+def test_get_engine_uses_configured_database_url(monkeypatch):
+    """get_engine should use database_url from settings."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test-db.sqlite")
+    get_settings.cache_clear()
+    db_module._engine = None
+
+    try:
+        engine = get_engine()
+        assert str(engine.url) == "sqlite:///./test-db.sqlite"
+    finally:
+        db_module._engine = None
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- add env-backed `database_url` and `api_key` settings so deploy/runtime configuration does not depend on missing attributes or hardcoded secrets
- fix database initialization to use the central typed settings and add focused tests covering env overrides
- document the correct Fly.io deployment path and required production environment variables

## Related issues
- fixes #68
- relates to #70

## Validation
- `uv run pytest tests/unit/api/test_auth.py tests/unit/core/test_config.py tests/unit/core/test_db.py tests/integration/test_health_router.py -q`
- `uv run python -c "from app.core.db import get_engine; print(get_engine().url)"`